### PR TITLE
If no dest is given (as third argument to npm run start switchboard_v…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,12 @@
 import generate from "./generator.js";
 import {TemplateType} from "./types.js";
 
-//let dest:string;
+
 export const dest = process.argv[3] ?? "./";
+
 async function main() {
   const filename = process.argv[2] ?? "switchboard_v2";
-    //dest =  process.argv[3];
-   // export const PACKAGE_ROOT: string = "./"
-  console.log("\n");
-  console.log("Destination: " + dest);
+
   await generate(filename,
     [
       TemplateType.Types,

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -17,8 +17,11 @@ export class Paths {
   }
 
   get outputDir() {
-   // return path.join(this.rootDir.toString(), 'output')
-    return dest.toString()
+    if(dest == "./"){ //If no dest was set, just put it under the root/output
+      return path.join(this.rootDir.toString(), 'output')
+    } else {
+      return dest.toString()
+    }
   }
 
   get projectDir() {


### PR DESCRIPTION
…2 "dest"), it puts it now right under root/output.

Now if no argument is given as dest, it will take the root dir from the paths file.