### PR TITLE
Fix/new parser interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Currently, you can run the indexer generator CLI here from source:
 1. `npm run build`
 2. You have two options, generating your indexer from a local Anchor IDL, or from a remote one:
    1. Providing the IDL path:`node ./dist/index.js -f ./path/to/idl/marinade_finance.json`
-   2. Providing your program address `node ./dist/index.js -a JUP3c2Uh3WA4Ng34tw6kPd2G4C5BB21Xo36Je1s32Ph`
+   2. Providing your program address `node ./dist/index.js -a MarBmsSgKXdrN1egZf5sqe1TMai9K1rChYNDJgjq7aD`
        (For this option you need to have anchor installed and your program published on https://www.apr.dev/)
 
 ## Deploying a new Indexer

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -120,7 +120,7 @@ export default async function generate(idl: Idl, paths: Paths, toGenerate: Templ
     mkdirSync(paths.utilsDir)
   if(!existsSync(paths.layaoutsDir))
     mkdirSync(paths.layaoutsDir)
-  const { accountLayouts, ixLayouts, indexLayouts } = renderLayoutsFiles(idl.name, instructionsView, accountsView);
+  const { accountLayouts, ixLayouts, indexLayouts, layoutLayouts } = renderLayoutsFiles(idl.name, instructionsView, accountsView);
   try {
     if(accountLayouts) {
       writeFileSync(paths.layoutsFile('accounts'), format(accountLayouts, DEFAULT_FORMAT_OPTS));
@@ -129,6 +129,7 @@ export default async function generate(idl: Idl, paths: Paths, toGenerate: Templ
       writeFileSync(paths.layoutsFile('instructions'), format(ixLayouts, DEFAULT_FORMAT_OPTS));
     }
     writeFileSync(paths.layoutsFile('index'), format(indexLayouts, DEFAULT_FORMAT_OPTS));
+    writeFileSync(paths.layoutsFile('layout'), format(layoutLayouts, DEFAULT_FORMAT_OPTS));
   } catch (err) {
     console.log(`Failed to format on layouts folder`)
     logError(err)

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -120,7 +120,7 @@ export default async function generate(idl: Idl, paths: Paths, toGenerate: Templ
     mkdirSync(paths.utilsDir)
   if(!existsSync(paths.layaoutsDir))
     mkdirSync(paths.layaoutsDir)
-  const { accountLayouts, ixLayouts, indexLayouts } = renderLayoutsFiles(instructionsView, accountsView);
+  const { accountLayouts, ixLayouts, indexLayouts } = renderLayoutsFiles(idl.name, instructionsView, accountsView);
   try {
     if(accountLayouts) {
       writeFileSync(paths.layoutsFile('accounts'), format(accountLayouts, DEFAULT_FORMAT_OPTS));

--- a/src/render-api.ts
+++ b/src/render-api.ts
@@ -8,9 +8,11 @@ export function renderApiFiles(Name: string, instructions: ViewInstructions | un
   const resolversApi: string = `import MainDomain from '../domain/main.js'
 import {
   AccountType,
-  Global${Name}Stats,
   ParsedEvents,
   InstructionType,
+} from '../utils/layouts/index.js'
+import {
+  Global${Name}Stats,
   ${Name}AccountInfo,
   ${Name}ProgramData,
 } from '../types.js'
@@ -213,7 +215,7 @@ import {
   GraphQLUnionType,
 } from 'graphql'
 import { GraphQLBigNumber, GraphQLLong } from '@aleph-indexer/core'
-import { InstructionType } from '../types.js'
+import { InstructionType } from '../utils/layouts/index.js'
 
 // ------------------- TYPES ---------------------------
 

--- a/src/render-dal.ts
+++ b/src/render-dal.ts
@@ -2,7 +2,7 @@ export function renderDALFiles(){
 
   const eventDal = `import BN from 'bn.js'
 import { EntityStorage } from '@aleph-indexer/core'
-import { ParsedEvents } from '../types.js'
+import { ParsedEvents } from '../utils/layouts/index.js'
 
 export type EventStorage = EntityStorage<ParsedEvents>
 

--- a/src/render-discoverer.ts
+++ b/src/render-discoverer.ts
@@ -6,7 +6,8 @@ export function renderDiscovererFiles(Name: string, filename: string){
     ${NAME}_PROGRAM_ID,
     ${NAME}_PROGRAM_ID_PK,
 } from '../../constants.js'
-import { AccountType, ${Name}AccountInfo } from '../../types.js'
+import { AccountType } from '../../utils/layouts/index.js'
+import { ${Name}AccountInfo } from '../../types.js'
 import {
     ACCOUNT_DISCRIMINATOR,
     ACCOUNTS_DATA_LAYOUT,

--- a/src/render-domain.ts
+++ b/src/render-domain.ts
@@ -11,7 +11,8 @@ import {
   AccountStats,
 } from '@aleph-indexer/framework'
 import { EventDALIndex, EventStorage } from '../dal/event.js'
-import { ParsedEvents, ${Name}AccountInfo } from '../types.js'
+import { ParsedEvents } from '../utils/layouts/index.js'
+import { ${Name}AccountInfo } from '../types.js'
 
 export class AccountDomain {
   constructor(
@@ -65,7 +66,8 @@ import {
 } from '@aleph-indexer/framework'
 import { eventParser as eParser } from '../parsers/event.js'
 import { createEventDAL } from '../dal/event.js'
-import { ParsedEvents, ${Name}AccountInfo } from '../types.js'
+import { ParsedEvents } from '../utils/layouts/index.js'
+import { ${Name}AccountInfo } from '../types.js'
 import { AccountDomain } from './account.js'
 import { createAccountStats } from './stats/timeSeries.js'
 import { ${NAME}_PROGRAM_ID } from '../constants.js'
@@ -188,12 +190,14 @@ import {
   AccountStats,
 } from '@aleph-indexer/framework'
 import {
+  AccountType,
+  ParsedEvents,
+} from '../utils/layouts/index.js'
+import {
   Global${Name}Stats,
   ${Name}Stats,
   ${Name}ProgramData,
-  AccountType,
   ${Name}AccountInfo,
-  ParsedEvents,
 } from '../types.js'
 import ${Name}Discoverer from './discoverer/${filename}.js'
 

--- a/src/render-layouts.ts
+++ b/src/render-layouts.ts
@@ -163,15 +163,16 @@ export * from './accounts.js'
 export * from './instructions.js'
 export * from './solita/index.js'
 
-export default class implements LayoutImplementation {
-  name = '${name}'
-  programID = ${NAME}_PROGRAM_ID
-  accountLayoutMap = IX_ACCOUNTS_LAYOUT
-  dataLayoutMap = IX_DATA_LAYOUT
-  accountDataLayoutMap = ACCOUNTS_DATA_LAYOUT
-  eventType = InstructionType
-
-  getInstructionType = getInstructionType
+export default {
+    [${NAME}_PROGRAM_ID]: {
+    name: '${name}',
+    programID: ${NAME}_PROGRAM_ID,
+    accountLayoutMap: IX_ACCOUNTS_LAYOUT,
+    dataLayoutMap: IX_DATA_LAYOUT,
+    accountDataLayoutMap: ACCOUNTS_DATA_LAYOUT,
+    eventType: InstructionType,
+    getInstructionType
+  } as LayoutImplementation
 }
 `
 

--- a/src/render-layouts.ts
+++ b/src/render-layouts.ts
@@ -154,27 +154,31 @@ export type ParsedEvents =
     }
 
     const indexLayouts = 
-`import { ${NAME}_PROGRAM_ID } from "../../constants.js"
-import { LayoutImplementation } from "@aleph-indexer/framework"
-import { ACCOUNTS_DATA_LAYOUT } from './accounts.js'
-import { InstructionType, IX_DATA_LAYOUT, getInstructionType, IX_ACCOUNTS_LAYOUT } from './instructions.js'
-
-export * from './accounts.js'
+`export * from './accounts.js'
 export * from './instructions.js'
 export * from './solita/index.js'
+`
+    const layoutLayouts =
+`import { ${NAME}_PROGRAM_ID } from '../../constants.js'
+import { ACCOUNTS_DATA_LAYOUT } from './accounts.js'
+import {
+  InstructionType,
+  IX_DATA_LAYOUT,
+  getInstructionType,
+  IX_ACCOUNTS_LAYOUT,
+} from './instructions.js'
 
 export default {
-    [${NAME}_PROGRAM_ID]: {
+  [${NAME}_PROGRAM_ID]: {
     name: '${name}',
     programID: ${NAME}_PROGRAM_ID,
     accountLayoutMap: IX_ACCOUNTS_LAYOUT,
     dataLayoutMap: IX_DATA_LAYOUT,
     accountDataLayoutMap: ACCOUNTS_DATA_LAYOUT,
     eventType: InstructionType,
-    getInstructionType
-  } as LayoutImplementation
-}
-`
+    getInstructionType,
+  },
+}`
 
-    return { accountLayouts, ixLayouts, indexLayouts }
+    return { accountLayouts, ixLayouts, indexLayouts, layoutLayouts }
 }

--- a/src/render-layouts.ts
+++ b/src/render-layouts.ts
@@ -19,8 +19,6 @@ export function renderLayoutsFiles(filename: string, instructionsView: ViewInstr
         }  
         accountLayouts +=
 `} from './solita/index.js'
-import { ParsedAccounts, ParsedAccountsData } from './solita/index.js'
-import { BeetStruct, FixableBeetStruct } from '@metaplex-foundation/beet'
 
 export enum AccountType {
         `

--- a/src/render-layouts.ts
+++ b/src/render-layouts.ts
@@ -1,6 +1,9 @@
 import { ViewInstructions, ViewAccounts } from './types'
 
-export function renderLayoutsFiles(instructionsView: ViewInstructions | undefined, accountsView: ViewAccounts | undefined){
+export function renderLayoutsFiles(filename: string, instructionsView: ViewInstructions | undefined, accountsView: ViewAccounts | undefined){
+    const NAME = filename.toUpperCase()
+    const name = filename.toLowerCase()
+
     let accountLayouts: string = ""
 
     if(accountsView != undefined && accountsView.accounts.length > 0) {
@@ -151,9 +154,25 @@ export type ParsedEvents =
     }
 
     const indexLayouts = 
-`export * from './accounts.js'
+`import { ${NAME}_PROGRAM_ID } from "../../constants.js"
+import { LayoutImplementation } from "@aleph-indexer/framework"
+import { ACCOUNTS_DATA_LAYOUT } from './accounts.js'
+import { InstructionType, IX_DATA_LAYOUT, getInstructionType, IX_ACCOUNTS_LAYOUT } from './instructions.js'
+
+export * from './accounts.js'
 export * from './instructions.js'
 export * from './solita/index.js'
+
+export default class implements LayoutImplementation {
+  name = '${name}'
+  programID = ${NAME}_PROGRAM_ID
+  accountLayoutMap = IX_ACCOUNTS_LAYOUT
+  dataLayoutMap = IX_DATA_LAYOUT
+  accountDataLayoutMap = ACCOUNTS_DATA_LAYOUT
+  eventType = InstructionType
+
+  getInstructionType = getInstructionType
+}
 `
 
     return { accountLayouts, ixLayouts, indexLayouts }

--- a/src/render-parsers.ts
+++ b/src/render-parsers.ts
@@ -20,7 +20,7 @@ import {
 
 
 event += `
-} from '../types.js'
+} from '../utils/layouts/index.js'
 
 export class EventParser {
   parse(ixCtx: InstructionContextV1): ParsedEvents {

--- a/src/render-root.ts
+++ b/src/render-root.ts
@@ -100,7 +100,7 @@ async function main() {
     },
     parser: {
       instances: 1,
-      schemaPath: './dist/utils/layouts/index.js',
+      layoutPath: './dist/utils/layouts/index.js',
     },
     indexer: {
       dataPath,

--- a/src/render-root.ts
+++ b/src/render-root.ts
@@ -100,6 +100,7 @@ async function main() {
     },
     parser: {
       instances: 1,
+      schemaPath: './dist/utils/layouts/index.js',
     },
     indexer: {
       dataPath,

--- a/src/render-root.ts
+++ b/src/render-root.ts
@@ -45,8 +45,8 @@ services:
   "author": "ALEPH.im",
   "license": "ISC",
   "dependencies": {
-    "@aleph-indexer/core": "^1.0.13",
-    "@aleph-indexer/framework": "^1.0.13",
+    "@aleph-indexer/core": "^1.0.14",
+    "@aleph-indexer/framework": "^1.0.14",
     "@metaplex-foundation/beet": "0.7.1",
     "@metaplex-foundation/beet-solana": "0.4.0",
     "@solana/spl-token": "0.3.5",
@@ -74,7 +74,7 @@ async function main() {
   const workerDomainPath = path.join(__dirname, './src/domain/worker.js')
   const mainDomainPath = path.join(__dirname, './src/domain/main.js')
   const apiSchemaPath = path.join(__dirname, './src/api/index.js')
-  const layoutPath = path.join(__dirname, './src/utils/layouts/index.js')
+  const layoutPath = path.join(__dirname, './src/utils/layouts/layout.js')
 
   const instances = Number(config.INDEXER_INSTANCES || 2)
   const apiPort = Number(config.INDEXER_API_PORT || 8080)

--- a/src/render-root.ts
+++ b/src/render-root.ts
@@ -45,8 +45,8 @@ services:
   "author": "ALEPH.im",
   "license": "ISC",
   "dependencies": {
-    "@aleph-indexer/core": "^1.0.12",
-    "@aleph-indexer/framework": "^1.0.12",
+    "@aleph-indexer/core": "^1.0.13",
+    "@aleph-indexer/framework": "^1.0.13",
     "@metaplex-foundation/beet": "0.7.1",
     "@metaplex-foundation/beet-solana": "0.4.0",
     "@solana/spl-token": "0.3.5",
@@ -74,6 +74,7 @@ async function main() {
   const workerDomainPath = path.join(__dirname, './src/domain/worker.js')
   const mainDomainPath = path.join(__dirname, './src/domain/main.js')
   const apiSchemaPath = path.join(__dirname, './src/api/index.js')
+  const layoutPath = path.join(__dirname, './src/utils/layouts/index.js')
 
   const instances = Number(config.INDEXER_INSTANCES || 2)
   const apiPort = Number(config.INDEXER_API_PORT || 8080)
@@ -100,7 +101,7 @@ async function main() {
     },
     parser: {
       instances: 1,
-      layoutPath: './dist/utils/layouts/index.js',
+      layoutPath,
     },
     indexer: {
       dataPath,

--- a/src/render-src.ts
+++ b/src/render-src.ts
@@ -11,7 +11,7 @@ export function renderSrcFiles(Name: string, filename: string, instructionsView:
   constants = 
 `import { PublicKey } from '@solana/web3.js'
 import { config } from '@aleph-indexer/core'
-import { InstructionType } from './types.js'
+import { InstructionType } from './utils/layouts/index.js'
 
 export enum ProgramName {
   ${Name} = '${name}',
@@ -54,9 +54,6 @@ export const ${NAME}_PROGRAM_ID_PK = new PublicKey(${NAME}_PROGRAM_ID)
 `
   }
 
-    types += 
-`export * from './utils/layouts/index.js'
-`
     types +=
 `
 import { AccountStats } from '@aleph-indexer/framework'

--- a/src/render-src.ts
+++ b/src/render-src.ts
@@ -2,7 +2,7 @@ import { ViewInstructions } from "./types"
 
 export function renderSrcFiles(Name: string, filename: string, instructionsView: ViewInstructions | undefined, address?: string){
   const NAME = filename.toUpperCase()
-  const name = filename.toUpperCase()
+  const name = filename.toLowerCase()
 
   let constants = ''
   let types = ''

--- a/src/render-stats.ts
+++ b/src/render-stats.ts
@@ -13,7 +13,8 @@ export function renderStatsFiles(Name: string, filename: string, instructions: V
     TimeSeriesStats,
 } from '@aleph-indexer/framework'
 import { EventDALIndex, EventStorage } from '../../dal/event.js'
-import { ParsedEvents, ${Name}Info } from '../../types.js'
+import { ParsedEvents } from '../../utils/layouts/index.js'
+import { ${Name}Info } from '../../types.js'
 import statsAggregator from './statsAggregator.js'
 import eventAggregator from './timeSeriesAggregator.js'
 
@@ -71,15 +72,17 @@ export async function createAccountStats(
         timeSeriesAggregator = 
 `
 import {
-  ParsedEvents,
   ${Name}Info,
   EventType1Info,
   EventType2Info,
+} from '../../types.js'
+import {
+  ParsedEvents,
   ${instructions.instructions[0].name}Event,
   ${instructions.instructions[1].name}Event,
   ${instructions.instructions[2].name}Event,
   ${instructions.instructions[3].name}Event
-} from '../../types.js'
+} from '../../utils/layouts/index.js'
 import { collectionEvent1Whitelist, collectionEvent2Whitelist } from '../../constants.js' // @todo: set to discriminate different event collections
 
 // @todo: This is just an example to group some related instructions and process the data together


### PR DESCRIPTION
Add necessary generation of a default export to `output/<indexer_name>/src/utils/layouts/index.ts` to be imported into the new indexer framework's parsing worker.